### PR TITLE
War effort on Symfony 4 compatibility.

### DIFF
--- a/Command/CreateUserCommand.php
+++ b/Command/CreateUserCommand.php
@@ -2,7 +2,8 @@
 
 namespace Beelab\UserBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Beelab\UserBundle\Manager\LightUserManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -13,8 +14,25 @@ use Symfony\Component\Console\Question\Question;
  * Inspired by CreateUserCommand by FOSUserBundle
  * See https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Command/CreateUserCommand.php.
  */
-class CreateUserCommand extends ContainerAwareCommand
+class CreateUserCommand extends Command
 {
+    /**
+     * @var LightUserManagerInterface
+     */
+    private $manager;
+
+    /**
+     * CreateUserCommand constructor.
+     *
+     * @param LightUserManagerInterface $manager
+     */
+    public function __construct(LightUserManagerInterface $manager)
+    {
+        $this->manager = $manager;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -58,15 +76,14 @@ EOT
         }
         $password = $input->getArgument('password');
         $inactive = $input->getOption('inactive');
-        $manager = $this->getContainer()->get('beelab_user.light_manager');
 
-        $user = $manager->getInstance();
+        $user = $this->manager->getInstance();
         $user->setEmail($email);
         $user->setPlainPassword($password);
         $user->setActive(!$inactive);
 
         try {
-            $manager->create($user);
+            $this->manager->create($user);
             $output->writeln(sprintf('Created user <comment>%s</comment>', $email));
         } catch (\Exception $e) {
             $output->writeln(sprintf('<error>Error</error>, user <comment>%s</comment> not created. %s', $email, $e->getMessage()));

--- a/Command/PromoteUserCommand.php
+++ b/Command/PromoteUserCommand.php
@@ -2,18 +2,37 @@
 
 namespace Beelab\UserBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Beelab\UserBundle\Manager\LightUserManagerInterface;
+use Beelab\UserBundle\Manager\UserManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Inspired by CreateUserCommand by FOSUserBundle
  * See https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Command/PromoteUserCommand.php.
  */
-class PromoteUserCommand extends ContainerAwareCommand
+class PromoteUserCommand extends Command
 {
+    /**
+     * @var UserManagerInterface
+     */
+    private $manager;
+
+    /**
+     * PromoteUserCommand constructor.
+     *
+     * @param UserManagerInterface $manager
+     */
+    public function __construct(UserManagerInterface $manager)
+    {
+        $this->manager = $manager;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -43,8 +62,7 @@ EOT
         $email = $input->getArgument('email');
         $role = $input->getArgument('role');
 
-        $manager = $this->getContainer()->get('beelab_user.manager');
-        $user = $manager->loadUserByUsername($email);
+        $user = $this->manager->loadUserByUsername($email);
         if (empty($user)) {
             $output->writeln(sprintf('<error>Error</error>: user <comment>%s</comment> not found.', $email));
         } else {
@@ -52,7 +70,7 @@ EOT
                 $output->writeln(sprintf('User <comment>%s</comment> did already have <comment>%s</comment> role.', $email, $role));
             } else {
                 $user->addRole($role);
-                $manager->update($user);
+                $this->manager->update($user);
 
                 $output->writeln(sprintf('Role <comment>%s</comment> has been added to user <comment>%s</comment>.', $role, $email));
             }

--- a/Command/PromoteUserCommand.php
+++ b/Command/PromoteUserCommand.php
@@ -21,11 +21,6 @@ class PromoteUserCommand extends Command
      */
     private $manager;
 
-    /**
-     * PromoteUserCommand constructor.
-     *
-     * @param UserManagerInterface $manager
-     */
     public function __construct(UserManagerInterface $manager)
     {
         $this->manager = $manager;
@@ -33,10 +28,7 @@ class PromoteUserCommand extends Command
         parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -54,35 +46,34 @@ EOT
             ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = $input->getArgument('email');
         $role = $input->getArgument('role');
 
         $user = $this->manager->loadUserByUsername($email);
-        if (empty($user)) {
-            $output->writeln(sprintf('<error>Error</error>: user <comment>%s</comment> not found.', $email));
-        } else {
-            if ($user->hasRole($role)) {
-                $output->writeln(sprintf('User <comment>%s</comment> did already have <comment>%s</comment> role.', $email, $role));
-            } else {
-                $user->addRole($role);
-                $this->manager->update($user);
 
-                $output->writeln(sprintf('Role <comment>%s</comment> has been added to user <comment>%s</comment>.', $role, $email));
-            }
+        if (null === $user) {
+            $output->writeln(sprintf('<error>Error</error>: user <comment>%s</comment> not found.', $email));
+
+            return 1;
         }
+        if ($user->hasRole($role)) {
+            $output->writeln(sprintf('User <comment>%s</comment> did already have <comment>%s</comment> role.', $email, $role));
+        } else {
+            $user->addRole($role);
+            $this->manager->update($user);
+
+            $output->writeln(sprintf('Role <comment>%s</comment> has been added to user <comment>%s</comment>.', $role, $email));
+        }
+
+        return 0;
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @codeCoverageIgnore
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         if (!$input->getArgument('email')) {
             $question = new Question('Please choose an email:');

--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -26,10 +27,10 @@ class AuthController extends AbstractController
      *
      * @return Response
      */
-    public function loginAction(AuthorizationCheckerInterface $checker, LoggerInterface $logger, Request $request): Response
+    public function loginAction(AuthorizationCheckerInterface $checker, LoggerInterface $logger, Request $request, ParameterBagInterface $bag): Response
     {
         if ($checker->isGranted('IS_AUTHENTICATED_FULLY')) {
-            return $this->redirectToRoute($this->getParameter('beelab_user.route'));
+            return $this->redirectToRoute($bag->get('beelab_user.route'));
         }
 
         return $this->render('@BeelabUser\Auth\login.html.twig', [

--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -19,6 +19,12 @@ class AuthController extends AbstractController
      *
      * @Route("/login", name="login")
      * @Method("GET")
+     *
+     * @param AuthorizationCheckerInterface $checker
+     * @param LoggerInterface               $logger
+     * @param Request                       $request
+     *
+     * @return Response
      */
     public function loginAction(AuthorizationCheckerInterface $checker, LoggerInterface $logger, Request $request): Response
     {
@@ -26,7 +32,7 @@ class AuthController extends AbstractController
             return $this->redirectToRoute($this->getParameter('beelab_user.route'));
         }
 
-        return $this->render('BeelabUserBundle:User:login.html.twig', [
+        return $this->render('@BeelabUser\Auth\login.html.twig', [
             'last_username' => $request->getSession()->get(Security::LAST_USERNAME),
             'error' => $this->getLoginError($logger, $request),
         ]);

--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -142,7 +142,7 @@ class UserController extends AbstractController
             return $this->redirectToRoute($this->getParameter('beelab_user.route'));
         }
 
-        return $this->render('BeelabUserBundle:User:index.html.twig',[
+        return $this->render('BeelabUserBundle:User:password.html.twig', [
             'form' => $form->createView(),
         ]);
     }

--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -8,6 +8,7 @@ use Beelab\UserBundle\Manager\UserManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -131,7 +132,7 @@ class UserController extends AbstractController
      * @Route("/password", name="user_password")
      * @Method({"GET", "POST"})
      */
-    public function passwordAction(EventDispatcherInterface $dispatcher, UserManagerInterface $manager, Request $request): Response
+    public function passwordAction(EventDispatcherInterface $dispatcher, UserManagerInterface $manager, Request $request, ParameterBagInterface $bag): Response
     {
         $user = $this->getUser();
         $form = $this->createForm($this->getPasswordFormName(), $user);
@@ -139,7 +140,7 @@ class UserController extends AbstractController
             $manager->update($user);
             $dispatcher->dispatch('beelab_user.change_password', new UserEvent($user));
 
-            return $this->redirectToRoute($this->getParameter('beelab_user.route'));
+            return $this->redirectToRoute($bag->get('beelab_user.route'));
         }
 
         return $this->render('BeelabUserBundle:User:password.html.twig', [

--- a/DependencyInjection/BeelabUserExtension.php
+++ b/DependencyInjection/BeelabUserExtension.php
@@ -30,5 +30,6 @@ class BeelabUserExtension extends Extension
         $loader->load('forms.xml');
         $loader->load('services.xml');
         $loader->load('controllers.xml');
+        $loader->load('commands.xml');
     }
 }

--- a/DependencyInjection/BeelabUserExtension.php
+++ b/DependencyInjection/BeelabUserExtension.php
@@ -29,5 +29,6 @@ class BeelabUserExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('forms.xml');
         $loader->load('services.xml');
+        $loader->load('controllers.xml');
     }
 }

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Beelab\UserBundle\Command\CreateUserCommand">
+            <tag name="console.command" command="beelab:user:create"/>
+            <argument type="service" id="Beelab\UserBundle\Manager\UserManager"/>
+        </service>
+        <service id="Beelab\UserBundle\Command\PromoteUserCommand">
+            <tag name="console.command" command="beelab:user:promote"/>
+            <argument type="service" id="Beelab\UserBundle\Manager\UserManager"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -8,7 +8,6 @@
             <tag name="controller.service_arguments"/>
             <tag name="container.service_subscriber"/>
             <tag name="monolog.logger"/>
-            <bind key="$loginTemplate">%beelab_user.%</bind>
         </service>
     </services>
 </container>

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -9,5 +9,12 @@
             <tag name="container.service_subscriber"/>
             <tag name="monolog.logger"/>
         </service>
+
+        <service id="Beelab\UserBundle\Controller\UserController">
+            <tag name="controller.service_arguments"/>
+            <tag name="monolog.logger"/>
+            <tag name="container.service_subscriber"/>
+        </service>
+
     </services>
 </container>

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Beelab\UserBundle\Controller\AuthController">
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
+            <tag name="monolog.logger"/>
+            <bind key="$loginTemplate">%beelab_user.%</bind>
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,15 +11,18 @@
             <argument type="service" id="knp_paginator" on-invalid="ignore" />
             <tag name="twig.extension" />
         </service>
+        <service id="beelab_user.twig_extension" alias="Beelab\UserBundle\Twig\BeelabUserTwigExtension"/>
         <service id="Beelab\UserBundle\Listener\LastLoginListener" class="Beelab\UserBundle\Listener\LastLoginListener" public="true">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="beelab_user.manager" />
         </service>
+        <service id="beelab_user.login_listener" alias="Beelab\UserBundle\Listener\LastLoginListener"/>
         <service id="Beelab\UserBundle\Manager\LightUserManager" class="Beelab\UserBundle\Manager\LightUserManager" public="false">
             <argument>%beelab_user.user_class%</argument>
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="security.encoder_factory" />
         </service>
+        <service id="beelab_user.light_manager" alias="Beelab\UserBundle\Manager\LightUserManager"/>
         <service id="Beelab\UserBundle\Manager\LightUserManagerInterface" alias="Beelab\UserBundle\Manager\LightUserManager" />
         <service id="Beelab\UserBundle\Manager\UserManager" class="Beelab\UserBundle\Manager\UserManager" public="false">
             <argument>%beelab_user.user_class%</argument>
@@ -30,6 +33,7 @@
             <argument type="service" id="knp_paginator" on-invalid="ignore" />
             <argument type="service" id="event_dispatcher" />
         </service>
+        <service id="beelab_user.manager" alias="Beelab\UserBundle\Manager\UserManager"/>
         <service id="Beelab\UserBundle\Manager\UserManagerInterface" alias="Beelab\UserBundle\Manager\UserManager" />
     </services>
 

--- a/Tests/Command/PromoteUserCommandTest.php
+++ b/Tests/Command/PromoteUserCommandTest.php
@@ -3,27 +3,42 @@
 namespace Beelab\UserBundle\Tests\Command;
 
 use Beelab\UserBundle\Command\PromoteUserCommand;
+use Beelab\UserBundle\Entity\User;
+use Beelab\UserBundle\Manager\UserManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class PromoteUserCommandTest extends TestCase
 {
-    protected $command;
+    private $command;
+
+    private $manager;
+
+    private $user;
 
     protected function setUp(): void
     {
+        $this->manager = $this->createMock(UserManagerInterface::class);
+        $this->user = $this->createMock(User::class);
+
+        $this->manager->expects($this->any())->method('getInstance')->will($this->returnValue($this->user));
+
         $application = new Application();
-        $application->add(new PromoteUserCommand());
+        $application->add(new PromoteUserCommand($this->manager));
 
         $this->command = $application->find('beelab:user:promote');
     }
 
     public function testPromote(): void
     {
+        $this->manager->expects($this->once())->method('loadUserByUsername')->will($this->returnValue($this->user));
+        $this->user->expects($this->once())->method('hasRole')->will($this->returnValue(false));
+        $this->user->expects($this->once())->method('addRole');
+        $this->manager->expects($this->once())->method('update')->with($this->user);
+
         $input = ['email' => 'garak@example.org', 'role' => 'ROLE_ADMIN'];
 
-        $this->command->setContainer($this->getMockContainer());
         $tester = new CommandTester($this->command);
         $tester->execute(array_merge(['command' => $this->command->getName()], $input));
         $this->assertContains('Role '.$input['role'].' has been added to user '.$input['email'], $tester->getDisplay());
@@ -31,9 +46,10 @@ class PromoteUserCommandTest extends TestCase
 
     public function testUserNotFound(): void
     {
+        $this->manager->expects($this->once())->method('loadUserByUsername')->will($this->returnValue(null));
+
         $input = ['email' => 'garak@example.org', 'role' => 'ROLE_ADMIN'];
 
-        $this->command->setContainer($this->getMockContainer(false));
         $tester = new CommandTester($this->command);
         $tester->execute(array_merge(['command' => $this->command->getName()], $input));
         $this->assertContains('Error: user '.$input['email'].' not found', $tester->getDisplay());
@@ -41,34 +57,13 @@ class PromoteUserCommandTest extends TestCase
 
     public function testHasAlreadyRole(): void
     {
+        $this->manager->expects($this->once())->method('loadUserByUsername')->will($this->returnValue($this->user));
+        $this->user->expects($this->once())->method('hasRole')->will($this->returnValue(true));
+
         $input = ['email' => 'garak@example.org', 'role' => 'ROLE_USER'];
 
-        $this->command->setContainer($this->getMockContainer(true, $input['role']));
         $tester = new CommandTester($this->command);
         $tester->execute(array_merge(['command' => $this->command->getName()], $input));
         $this->assertContains('User '.$input['email'].' did already have '.$input['role'].' role', $tester->getDisplay());
-    }
-
-    private function getMockContainer(bool $found = true, string $role = 'ROLE_ADMIN'): Container
-    {
-        $userManager = $this->getMockBuilder('Beelab\UserBundle\Manager\UserManager')->disableOriginalConstructor()->getMock();
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')->disableOriginalConstructor()->getMock();
-        $user = $this->createMock('Beelab\UserBundle\Entity\User');
-
-        $container->expects($this->once())->method('get')->with('beelab_user.manager')->will($this->returnValue($userManager));
-        if ($found) {
-            $userManager->expects($this->at(0))->method('loadUserByUsername')->will($this->returnValue($user));
-            if ('ROLE_ADMIN' === $role) {
-                $user->expects($this->at(0))->method('hasRole')->with($role)->will($this->returnValue(false));
-                $user->expects($this->at(1))->method('addRole')->with($role);
-                $userManager->expects($this->at(1))->method('update')->with($user);
-            } else {
-                $user->expects($this->at(0))->method('hasRole')->with($role)->will($this->returnValue(true));
-            }
-        } else {
-            $userManager->expects($this->once())->method('loadUserByUsername')->will($this->returnValue(null));
-        }
-
-        return $container;
     }
 }

--- a/Tests/Controller/AuthControllerTest.php
+++ b/Tests/Controller/AuthControllerTest.php
@@ -6,6 +6,7 @@ use Beelab\UserBundle\Controller\AuthController;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,6 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Twig\Environment;
 
 /**
  * @group unit
@@ -43,12 +45,15 @@ class AuthControllerTest extends TestCase
         $request = $this->createMock(Request::class);
         $router = $this->createMock(UrlGeneratorInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
+        $bag = $this->createMock(ParameterBagInterface::class);
 
+        $bag->expects($this->once())->method('get')->will($this->returnValue('an_url'));
+        $this->container->expects($this->at(0))->method('get')->with('router')->will($this->returnValue($router));
         $authChecker->expects($this->any())->method('isGranted')->with('IS_AUTHENTICATED_FULLY')
             ->will($this->returnValue(true));
-        $router->expects($this->once())->method('generate')->will($this->returnValue('url'));
+        $router->expects($this->once())->method('generate')->will($this->returnValue('an_url'));
 
-        $response = $this->controller->loginAction($authChecker, $logger, $request);
+        $response = $this->controller->loginAction($authChecker, $logger, $request, $bag);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
     }
@@ -60,7 +65,12 @@ class AuthControllerTest extends TestCase
         $request->attributes = new ParameterBag(['_security.last_username' => 'user']);
         $session = $this->createMock(SessionInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
+        $bag = $this->createMock(ParameterBagInterface::class);
+        $twig = $this->createMock(Environment::class);
 
+        $this->container->expects($this->at(0))->method('has')->with('templating')->will($this->returnValue(false));
+        $this->container->expects($this->at(1))->method('has')->with('twig')->will($this->returnValue(true));
+        $this->container->expects($this->at(2))->method('get')->with('twig')->will($this->returnValue($twig));
         $authChecker->expects($this->any())->method('isGranted')->with('IS_AUTHENTICATED_FULLY')
             ->will($this->returnValue(false));
         $request->expects($this->any())->method('getSession')->will($this->returnValue($session));
@@ -68,7 +78,7 @@ class AuthControllerTest extends TestCase
         $session->expects($this->at(0))->method('get')->with('_security.last_username')
             ->will($this->returnValue('user'));
 
-        $response = $this->controller->loginAction($authChecker, $logger, $request);
+        $response = $this->controller->loginAction($authChecker, $logger, $request, $bag);
 
         $this->assertInstanceOf(Response::class, $response);
     }

--- a/Tests/DependencyInjection/BeelabUserExtensionTest.php
+++ b/Tests/DependencyInjection/BeelabUserExtensionTest.php
@@ -28,7 +28,6 @@ class BeelabUserExtensionTest extends TestCase
         $extension = new BeelabUserExtension();
         $configs = [
             ['user_class' => 'foo'],
-            ['user_manager_class' => 'foo'],
             ['user_form_type' => 'foo'],
             ['password_form_type' => 'foo'],
             ['layout' => 'bar'],

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "sensio/framework-extra-bundle": "^3.0|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0",
         "symfony/console": "^3.4|^4.0",
-        "symfony/dependency-injection": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/doctrine-bridge": "^3.4|^4.0",
         "symfony/form": "^3.4|^4.0",
         "symfony/security": "^3.4|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/doctrine-bridge": "^3.4|^4.0",
         "symfony/form": "^3.4|^4.0",
         "symfony/security": "^3.4|^4.0",
+        "symfony/templating": "^3.4|^4.0",
         "symfony/validator": "^3.4|^4.0",
         "twig/twig": ">=1.26"
     },


### PR DESCRIPTION
Hey!
Here's a few commits towards sf4 compatibility.

* Added service aliases to keep BC w/ BeelabUserPasswordBundle and older versions of Symfony.
* Registered controllers as services.
* Registered commands as services.
* Usage the new ParameterBag component in controllers to access parameters.

I'm using this fork on a symfony 4.1 installation, seems to be working fine 👌
